### PR TITLE
Create bigpanda-webhook3

### DIFF
--- a/extensions/eda/rulebooks/bigpanda-webhook3
+++ b/extensions/eda/rulebooks/bigpanda-webhook3
@@ -1,0 +1,46 @@
+# rulebook.yml
+---
+- name: BigPanda Webhook Rulebook 1
+  hosts: all
+  sources:
+    - ansible.eda.webhook:
+        host: 0.0.0.0
+        port: 6001
+  rules:
+    - name: Demo Part 1 - Execute Assign to BigPanda UUID and Check Pods Playbook
+      condition: |
+        event.payload.incident is defined and
+        event.payload.incident.resolved == false and 
+        event.payload.incident.active == true and
+        event.payload.incident.alerts is not search("trace.internal.writer", ignorecase=true) and
+        event.payload.metadata.event_types is search("incident#updated", ignorecase=true)
+      action:
+        run_job_template:
+          name: "Check Pods"
+          organization: Default
+
+    - name: Demo Part 2 - Execute Remediation Steps on the Monitoring Agent
+      condition: |
+        event.payload.incident is defined and 
+        event.payload.incident.resolved == false and 
+        event.payload.incident.active == true and
+        event.payload.incident.alerts is search("trace.internal.writer", ignorecase=true) and
+        event.payload.metadata.event_types is search("incident#updated", ignorecase=true) and
+        event.payload.incident.status != "Warning"
+      action:
+        run_job_template:
+          name: "Restart Agent"
+          organization: Default
+
+    - name: Demo Part 3 - Execute Cleanup Playbook
+      condition: |
+        event.payload.incident is defined and 
+        event.payload.incident.status == "Warning"
+      action:
+        run_job_template:
+          name: "Cleanup"
+          organization: Default
+    - name: Log Event
+      condition: event.meta is defined
+      action:
+        debug:


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Creates a new BigPanda Webhook rulebook for automated incident response. Implements a webhook listener and defines rules for executing job templates based on specific incident conditions, enabling streamlined incident management and remediation processes.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/bigpandaio/ansible-demo/4?tool=ast&topic=Webhook+Config>Webhook Config</a>
        </td><td>Configures the BigPanda webhook listener to receive incident data on a specified host and port.<details><summary>Modified files (1)</summary><ul><li>extensions/eda/rulebooks/bigpanda-webhook3</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/bigpandaio/ansible-demo/4?tool=ast&topic=Incident+Automation>Incident Automation</a>
        </td><td>Implements rules for automated incident response, including pod checks, agent restarts, and cleanup actions based on specific incident conditions.<details><summary>Modified files (1)</summary><ul><li>extensions/eda/rulebooks/bigpanda-webhook3</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Join @bpbsibille and the rest of your team on <a href=https://baz.co/changes/bigpandaio/ansible-demo/4?tool=ast>(Baz)</a>.