### PR TITLE
Free Up Disk Space: fix {{disk_name}} to constant (on the final task level)

### DIFF
--- a/extensions/eda/playbooks/check_disk_space.yml
+++ b/extensions/eda/playbooks/check_disk_space.yml
@@ -74,8 +74,8 @@
           Disk Space Analysis for {{ host_name }}:
           ================================================================================
           DISK NAME      UUID                                  TOTAL     USED      FREE    USE%    MOUNT
-          /dev/sda1      123e4567-e89b-12d3-a456-426614174000  500G     125G       375G    25%     /
-          /dev/sdb1      987fcdeb-a987-54cd-b321-765432198000  200G      60G       140G    30%     /data
-          /dev/sdc1      456abcde-f123-89ab-cdef-012345678900  100G      98G         2G    98%     /var/log
-          /dev/sdd1      789fedc-b456-89ab-cdef-012345678900   300G      90G       210G    30%     /backup
+          /dev/sda1      123e4567-e89b-12d3-a456-426614174000  500G      125G      375G    25%     /
+          /dev/sdb1      987fcdeb-a987-54cd-b321-765432198000  200G       60G      140G    30%     /data
+          /dev/sdc1      456abcde-f123-89ab-cdef-012345678900  100G       98G        2G    98%     /var/log
+          /dev/sdd1      789fedc-b456-89ab-cdef-012345678900   300G       90G      210G    30%     /backup
           

--- a/extensions/eda/playbooks/free_up_disk_space.yml
+++ b/extensions/eda/playbooks/free_up_disk_space.yml
@@ -56,8 +56,8 @@
         msg: |
           Updated Disk Space Analysis for {{ host_name }}:
           ================================================================================
-          DISK NAME         UUID                                  TOTAL     USED      FREE    USE%    MOUNT
-          /dev/sda1         123e4567-e89b-12d3-a456-426614174000  500G      125G      375G    25%     /
-          /dev/sdb1         987fcdeb-a987-54cd-b321-765432198000  200G       60G      140G    30%     /data
-          {{ disk_name }}   456abcde-f123-89ab-cdef-012345678900  100G       30G       70G    30%     /var/log
-          /dev/sdd1         789fedc-b456-89ab-cdef-012345678900   300G       90G      210G    30%     /backup
+          DISK NAME      UUID                                  TOTAL     USED      FREE    USE%    MOUNT
+          /dev/sda1      123e4567-e89b-12d3-a456-426614174000  500G      125G      375G    25%     /
+          /dev/sdb1      987fcdeb-a987-54cd-b321-765432198000  200G       60G      140G    30%     /data
+          /dev/sdc1      456abcde-f123-89ab-cdef-012345678900  100G       30G       70G    30%     /var/log
+          /dev/sdd1      789fedc-b456-89ab-cdef-012345678900   300G       90G      210G    30%     /backup


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed inconsistent spacing in disk space report outputs.

- Replaced `{{ disk_name }}` with a constant `/dev/sdc1` in `free_up_disk_space.yml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check_disk_space.yml</strong><dd><code>Fix spacing inconsistencies in disk space report</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/eda/playbooks/check_disk_space.yml

<li>Corrected spacing in disk space report output.<br> <li> Ensured consistent alignment for disk space values.


</details>


  </td>
  <td><a href="https://github.com/bigpandaio/ansible-demo/pull/6/files#diff-d9dbee894eab5b637a83a08c912b2b1efa529a60aa4644bc656d07cb82269e91">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>free_up_disk_space.yml</strong><dd><code>Replace variable and fix spacing in report</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

extensions/eda/playbooks/free_up_disk_space.yml

<li>Replaced <code>{{ disk_name }}</code> with <code>/dev/sdc1</code> for consistency.<br> <li> Fixed spacing issues in updated disk space report output.


</details>


  </td>
  <td><a href="https://github.com/bigpandaio/ansible-demo/pull/6/files#diff-c4b1266f650cc77bedcb0a4d5368a83c71ba13669fff46f182dc8e1f2cd95512">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>